### PR TITLE
Network + state source and staging models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,6 +14,7 @@ vars:
   campaign_stats: "{{ source('google_ads','campaign_stats') }}"
   keyword_stats: "{{ source('google_ads','keyword_stats') }}"
   account_stats: "{{ source('google_ads','account_stats') }}"
+  campaign_network_state_stats: " {{source('google_ads', 'campaign_network_state_stats') }}"
 
   google_ads__ad_group_stats_passthrough_metrics: []
   google_ads__ad_stats_passthrough_metrics: []

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ vars:
 
 models:
   google_ads_source:
-    +schema: google_ads_source
+    schema: dw_marketing_sources
     +materialized: table
     tmp:
       +materialized: view

--- a/macros/get_campaign_network_state_stats_columns.sql
+++ b/macros/get_campaign_network_state_stats_columns.sql
@@ -1,0 +1,19 @@
+{% macro get_campaign_network_state_stats_columns() %}
+
+{% set columns = [
+    {"name": "customer_id", "datatype": dbt_utils.type_int()},
+    {"name": "date", "datatype": "date"},
+    {"name": "campaign_id", "datatype": dbt_utils.type_int()},
+    {"name": "campaign_name", "datatype": dbt_utils.type_string()},
+    {"name": "clicks", "datatype": dbt_utils.type_int()},
+    {"name": "cost_micros", "datatype": dbt_utils.type_int()},
+    {"name": "impressions", "datatype": dbt_utils.type_int()},
+    {"name": "ad_network_type", "datatype": dbt_utils.type_string()},
+    {"name": "geo_target_state", "datatype": dbt_utils.type_string()}
+] %}
+
+{{ fivetran_utils.add_pass_through_columns(columns, var('google_ads__ad_stats_passthrough_metrics')) }}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/macros/get_campaign_network_state_stats_columns.sql
+++ b/macros/get_campaign_network_state_stats_columns.sql
@@ -9,7 +9,8 @@
     {"name": "cost_micros", "datatype": dbt_utils.type_int()},
     {"name": "impressions", "datatype": dbt_utils.type_int()},
     {"name": "ad_network_type", "datatype": dbt_utils.type_string()},
-    {"name": "geo_target_state", "datatype": dbt_utils.type_string()}
+    {"name": "geo_target_state", "datatype": dbt_utils.type_string()},
+    {"name": "customer_currency_code", "datatype": dbt_utils.type_string()}
 ] %}
 
 {{ fivetran_utils.add_pass_through_columns(columns, var('google_ads__ad_stats_passthrough_metrics')) }}

--- a/models/src_google_ads.yml
+++ b/models/src_google_ads.yml
@@ -8,7 +8,7 @@ sources:
     loader: Fivetran
     loaded_at_field: _fivetran_synced
 
-    freshness: 
+    freshness:
       warn_after: {count: 48, period: hour}
       error_after: {count: 168, period: hour}
     config:
@@ -145,7 +145,7 @@ sources:
           - name: status
             description: The current status of the ad group criterion.
           - name: keyword_match_type
-            description: The match type which dictate how closely the keyword needs to match with the user’s search query so that the ad can be considered for the auction. 
+            description: The match type which dictate how closely the keyword needs to match with the user’s search query so that the ad can be considered for the auction.
           - name: keyword_text
             description: The text used within the keyword criterion that is being matched against.
 
@@ -230,3 +230,27 @@ sources:
             description: "{{ doc('cost') }}"
           - name: impressions
             description: "{{ doc('impressions') }}"
+      - name: campaign_network_state_stats
+        description: A custom report at the network and state level.
+        identifier: "{{ var('google_ads_account_stats_identifier', 'campaign_network_state_stats') }}"
+        columns:
+          - name: customer_id
+            description: "{{ doc('external_customer_id') }}"
+          - name: date
+            description: "{{ doc('date') }}"
+          - name: campaign_id
+            description: "{{ doc('campaign_id') }}"
+          - name: campaign_name
+            description: "{{ doc('campaign_name') }}"
+          - name: ad_network_type
+            description: "{{ doc('ad_network_type') }}"
+          - name: clicks
+            description: "{{ doc('clicks') }}"
+          - name: cost_micros
+            description: "{{ doc('cost') }}"
+          - name: impressions
+            description: "{{ doc('impressions') }}"
+          - name: _fivetran_id
+            description: The unique ID of the keyword record.
+          - name: geo_target_state
+            description: The GeoTargetConstants ID for the state where the ads were served.

--- a/models/stg_google_ads__campaign_network_state_stats.sql
+++ b/models/stg_google_ads__campaign_network_state_stats.sql
@@ -1,0 +1,51 @@
+{{ config(enabled=var('ad_reporting__google_ads_enabled', True)) }}
+
+with base as (
+
+    select *
+    from {{ ref('stg_google_ads__campaign_network_state_stats_tmp') }}
+
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_google_ads__campaign_network_state_stats_tmp')),
+                staging_columns=get_ad_stats_columns()
+            )
+        }}
+
+    from base
+),
+
+states as (
+
+    select
+      *
+    from {{ ref('google_ads_state_mapping') }}
+
+)
+
+final as (
+
+    select
+        fields.customer_id as account_id,
+        fields.campaign_id,
+        fields.campaign_name,
+        fields.date as date_day,
+        fields.ad_network_type,
+        states.state_name,
+        fields.customer_currency_code,
+        fields.clicks,
+        fields.cost_micros / 1000000.0 as spend,
+        fields.impressions
+        {{ fivetran_utils.fill_pass_through_columns('google_ads__ad_stats_passthrough_metrics') }}
+
+    from fields
+    left join states on
+      regexp_substr(fields.geo_target_state, '\\d+') = states.geo_target_state_id
+)
+
+select * from final

--- a/models/stg_google_ads__campaign_network_state_stats.sql
+++ b/models/stg_google_ads__campaign_network_state_stats.sql
@@ -13,7 +13,7 @@ fields as (
         {{
             fivetran_utils.fill_staging_columns(
                 source_columns=adapter.get_columns_in_relation(ref('stg_google_ads__campaign_network_state_stats_tmp')),
-                staging_columns=get_ad_stats_columns()
+                staging_columns=get_campaign_network_state_stats_columns()
             )
         }}
 

--- a/models/stg_google_ads__campaign_network_state_stats.sql
+++ b/models/stg_google_ads__campaign_network_state_stats.sql
@@ -26,7 +26,7 @@ states as (
       *
     from {{ ref('google_ads_state_mapping') }}
 
-)
+),
 
 final as (
 

--- a/models/tmp/stg_google_ads__campaign_network_state_stats_tmp.sql
+++ b/models/tmp/stg_google_ads__campaign_network_state_stats_tmp.sql
@@ -1,0 +1,4 @@
+{{ config(enabled=var('ad_reporting__google_ads_enabled', True)) }}
+
+select *
+from {{ var('campaign_network_state_stats') }}


### PR DESCRIPTION
Sourcing and staging the custom reporting table (`google_ads.campaign_network_state_stats`) and changing the build schema to `dw_marketing_sources`. 