### PR TITLE
Incorporate historical BPI backfill data

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,7 +14,8 @@ vars:
   campaign_stats: "{{ source('google_ads','campaign_stats') }}"
   keyword_stats: "{{ source('google_ads','keyword_stats') }}"
   account_stats: "{{ source('google_ads','account_stats') }}"
-  campaign_network_state_stats: " {{source('google_ads', 'campaign_network_state_stats') }}"
+  campaign_network_state_stats: "{{ source('google_ads', 'campaign_network_state_stats') }}"
+  bpi_backfill__campaign_network_state_stats: " {{ source('google_ads', 'bpi_backfill__campaign_network_state_stats') }}"
 
   google_ads__ad_group_stats_passthrough_metrics: []
   google_ads__ad_stats_passthrough_metrics: []

--- a/macros/get_bpi_backfill__campaign_network_state_stats_columns.sql
+++ b/macros/get_bpi_backfill__campaign_network_state_stats_columns.sql
@@ -1,0 +1,20 @@
+{% macro get_bpi_backfill__campaign_network_state_stats_columns() %}
+
+{% set columns = [
+    {"name": "account_id", "datatype": dbt_utils.type_int()},
+    {"name": "day", "datatype": "date"},
+    {"name": "campaign_id", "datatype": dbt_utils.type_int()},
+    {"name": "campaign", "datatype": dbt_utils.type_string()},
+    {"name": "clicks", "datatype": dbt_utils.type_int()},
+    {"name": "cost", "datatype": dbt_utils.type_int()},
+    {"name": "impr", "datatype": dbt_utils.type_int()},
+    {"name": "campaign_type", "datatype": dbt_utils.type_string()},
+    {"name": "state_matched", "datatype": dbt_utils.type_string()},
+    {"name": "currency_code", "datatype": dbt_utils.type_string()}
+] %}
+
+{{ fivetran_utils.add_pass_through_columns(columns, var('google_ads__ad_stats_passthrough_metrics')) }}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/models/src_google_ads.yml
+++ b/models/src_google_ads.yml
@@ -254,3 +254,26 @@ sources:
             description: The unique ID of the keyword record.
           - name: geo_target_state
             description: The GeoTargetConstants ID for the state where the ads were served.
+      - name: bpi_backfill__campaign_network_state_stats
+        description: A historical report of BPI-owned campaigns, meant to be analagous to the campaign_network_state_stats report. Backfilled from CSV provided by paid media team.
+        #identifier: "{{ var('google_ads_account_stats_identifier', 'campaign_network_state_stats') }}"
+        columns:
+          - name: account_id
+            description: "{{ doc('external_customer_id') }}"
+          - name: campaign
+            description: "{{ doc('campaign_name') }}"
+          - name: campaign_id
+            description: "{{ doc('campaign_id') }}"
+          - name: campaign_type
+            description: "{{ doc('ad_network_type') }}"
+          - name: clicks
+            description: "{{ doc('clicks') }}"
+          - name: cost
+            description: "{{ doc('cost') }}"
+          - name: currency_code
+          - name: day
+            description: "{{ doc('date') }}"
+          - name: impr
+            description: "{{ doc('impressions') }}"
+          - name: state_matched
+            description: The name of the state where the ad was served

--- a/models/stg_google_ads.yml
+++ b/models/stg_google_ads.yml
@@ -103,7 +103,7 @@ models:
         description: "{{ doc('utm_content') }}"
       - name: utm_term
         description: "{{ doc('utm_term') }}"
-        
+
   - name: stg_google_ads__ad_stats
     description: Each record represents the daily performance of an ad in Google Ads broken down to the ad network, device type, and ad_group_id.
     tests:
@@ -202,7 +202,7 @@ models:
       - name: status
         description: The current status of the ad group criterion.
       - name: keyword_match_type
-        description: The match type which dictate how closely the keyword needs to match with the user’s search query so that the ad can be considered for the auction. 
+        description: The match type which dictate how closely the keyword needs to match with the user’s search query so that the ad can be considered for the auction.
       - name: keyword_text
         description: The text used within the keyword criterion that is being matched against.
       - name: is_most_recent_record
@@ -331,3 +331,41 @@ models:
         description: "{{ doc('cost') }}"
       - name: impressions
         description: "{{ doc('impressions') }}"
+
+  - name: stg_google_ads__campaign_network_state_stats
+    description: Each record represents the daily performance of an account in Google Ads broken down to the ad network and device type.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - account_id
+            - campaign_id
+            - ad_network_type
+            - state_name
+            - date_day
+    columns:
+      - name: account_id
+        description: "{{ doc('external_customer_id') }}"
+        tests:
+          - not_null
+      - name: date_day
+        description: "{{ doc('date') }}"
+        tests:
+          - not_null
+      - name: ad_network_type
+        description: "{{ doc('ad_network_type') }}"
+      - name: campaign_id
+        description: "{{ doc('campaign_id') }}"
+      - name: campaign_name
+        description: "{{ doc('campaign_name') }}"
+      - name: state_name
+        description: The state where the campaign content was served.
+      - name: customer_currency_code
+        description: The currency of the spend reported.
+      - name: clicks
+        description: "{{ doc('clicks') }}"
+      - name: spend
+        description: "{{ doc('cost') }}"
+      - name: impressions
+        description: "{{ doc('impressions') }}"
+      - name: sync_source
+        description: Whether the record originated from the historical BPI backfill or from the ACLU Fivetran sync.

--- a/models/stg_google_ads__bpi_backfill__campaign_network_state_stats.sql
+++ b/models/stg_google_ads__bpi_backfill__campaign_network_state_stats.sql
@@ -1,0 +1,44 @@
+{{ config(enabled=var('ad_reporting__google_ads_enabled', True)) }}
+
+with base as (
+
+    select *
+    from {{ ref('stg_google_ads__bpi_backfill__campaign_network_state_stats_tmp') }}
+
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_google_ads__bpi_backfill__campaign_network_state_stats_tmp')),
+                staging_columns=get_bpi_backfill__campaign_network_state_stats_columns()
+            )
+        }}
+
+    from base
+),
+
+final as (
+
+    select
+        fields.account_id::bigint as account_id,
+        fields.campaign_id::bigint as campaign_id,
+        fields.campaign as campaign_name,
+        fields.day::date as date_day,
+        case fields.campaign_type -- https://developers.google.com/google-ads/api/reference/rpc/v11/AdNetworkTypeEnum.AdNetworkType
+          when 'Display' then 'CONTENT'
+          when 'Search' then 'SEARCH'
+          when 'Video' then 'YOUTUBE_WATCH'
+        end as ad_network_type,
+        fields.state_matched as state_name,
+        fields.currency_code as customer_currency_code,
+        fields.clicks as clicks,
+        fields.cost as spend,
+        fields.impr as impressions
+        {{ fivetran_utils.fill_pass_through_columns('google_ads__ad_stats_passthrough_metrics') }}
+    from fields
+)
+
+select * from final

--- a/models/tmp/stg_google_ads__bpi_backfill__campaign_network_state_stats_tmp.sql
+++ b/models/tmp/stg_google_ads__bpi_backfill__campaign_network_state_stats_tmp.sql
@@ -1,0 +1,4 @@
+{{ config(enabled=var('ad_reporting__google_ads_enabled', True)) }}
+
+select *
+from {{ var('bpi_backfill__campaign_network_state_stats') }}


### PR DESCRIPTION
- Incorporate the historical BPI backfill data provided by paid media into the project
- Aggregate `campaign_network_state_stats` model to eliminate duplicate records, add uniqueness tests
- Update seed reference to point to new file in `dw_dbt`
- Add documentation for custom source and staging tables